### PR TITLE
Enforce Input File Compatibility for CSV Timeline and HTML Report Tasks

### DIFF
--- a/src/csv_timeline.py
+++ b/src/csv_timeline.py
@@ -34,6 +34,12 @@ TASK_METADATA = {
     "description": "Windows event log triage",
 }
 
+COMPATIBLE_INPUTS = {
+    "data_types": [],
+    "mime_types": ["application/x-ms-evtx"],
+    "filenames": ["*.evtx"],
+}
+
 
 @celery.task(bind=True, name=TASK_NAME, metadata=TASK_METADATA)
 def csv_timeline(
@@ -44,7 +50,12 @@ def csv_timeline(
     workflow_id=None,
     task_config={},
 ) -> str:
-    input_files = get_input_files(pipe_result, input_files or [])
+    input_files = get_input_files(
+        pipe_result, input_files or [], filter=COMPATIBLE_INPUTS
+    )
+    if not input_files:
+        raise RuntimeError("No compatible input files")
+
     output_files = []
 
     output_file = create_output_file(

--- a/src/html_report.py
+++ b/src/html_report.py
@@ -34,6 +34,12 @@ TASK_METADATA = {
     "description": "Windows event log triage",
 }
 
+COMPATIBLE_INPUTS = {
+    "data_types": [],
+    "mime_types": ["application/x-ms-evtx"],
+    "filenames": ["*.evtx"],
+}
+
 
 @celery.task(bind=True, name=TASK_NAME, metadata=TASK_METADATA)
 def html_report(
@@ -44,7 +50,11 @@ def html_report(
     workflow_id=None,
     task_config={},
 ) -> str:
-    input_files = get_input_files(pipe_result, input_files or [])
+    input_files = get_input_files(
+        pipe_result, input_files or [], filter=COMPATIBLE_INPUTS
+    )
+    if not input_files:
+        raise RuntimeError("No compatible input files")
     output_files = []
 
     output_file = create_output_file(


### PR DESCRIPTION
### Summary:
This change introduces input file compatibility checks for the `csv_timeline` and `html_report` tasks, ensuring they only process `.evtx` files and preventing unexpected behavior or errors with incompatible file types.

### Technical Details:
*   **Compatibility Definitions:**  Added `COMPATIBLE_INPUTS` dictionaries to both `src/csv_timeline.py` and `src/html_report.py`. These dictionaries define the accepted file types for each task based on `mime_types` ("application/x-ms-evtx") and `filenames` ("*.evtx").  This explicit declaration clarifies the intended input format for these tasks.
*   **Input Filtering:** Modified the `get_input_files` calls within both tasks to include the `filter` parameter, passing in the respective `COMPATIBLE_INPUTS` dictionaries. This ensures that only files matching the specified criteria are passed to the task for processing.
*   **Error Handling:** Introduced a `RuntimeError` in both tasks that is raised if no compatible input files are found after filtering. This prevents the tasks from proceeding with potentially invalid data and provides a clear error message for troubleshooting. This proactive error handling improves the robustness of the workflow.