### PR TITLE
feat(hayabusa): Allow setting a custom name for the hayabusa output c…

### DIFF
--- a/src/csv_timeline.py
+++ b/src/csv_timeline.py
@@ -30,6 +30,15 @@ TASK_NAME = "openrelik-worker-hayabusa.tasks.csv_timeline"
 TASK_METADATA = {
     "display_name": "Hayabusa CSV timeline",
     "description": "Windows event log triage",
+    "task_config": [
+        {
+            "name": "output_file_name",
+            "label": "Output file name",
+            "description": "Custom name for the output CSV file (without extension).",
+            "type": "text",
+            "required": False,
+        },
+    ],
 }
 
 COMPATIBLE_INPUTS = {
@@ -54,9 +63,18 @@ def csv_timeline(
 
     output_files = []
 
+
+    # Determine output file name from task_config if provided
+    custom_name = None
+    if task_config and task_config.get("output_file_name"):
+        custom_name = task_config["output_file_name"].strip()
+        if custom_name.endswith(".csv"):
+            custom_name = custom_name[:-4]
+
+    display_name = f"{custom_name}.csv" if custom_name else "Hayabusa_CSV_timeline.csv"
     output_file = create_output_file(
         output_path,
-        display_name="Hayabusa_CSV_timeline.csv",
+        display_name=display_name,
         data_type="openrelik:hayabusa:csv_timeline",
     )
 

--- a/src/html_report.py
+++ b/src/html_report.py
@@ -32,6 +32,15 @@ TASK_NAME = "openrelik-worker-hayabusa.tasks.html_report"
 TASK_METADATA = {
     "display_name": "Hayabusa HTML report",
     "description": "Windows event log triage",
+    "task_config": [
+        {
+            "name": "output_file_name",
+            "label": "Output file name",
+            "description": "Custom name for the output HTML file (without extension).",
+            "type": "text",
+            "required": False,
+        },
+    ],
 }
 
 COMPATIBLE_INPUTS = {
@@ -57,9 +66,18 @@ def html_report(
         raise RuntimeError("No compatible input files")
     output_files = []
 
+
+    # Determine output file name from task_config if provided
+    custom_name = None
+    if task_config and task_config.get("output_file_name"):
+        custom_name = task_config["output_file_name"].strip()
+        if custom_name.endswith(".html"):
+            custom_name = custom_name[:-5]
+
+    display_name = f"{custom_name}.html" if custom_name else "Hayabusa_HTML_report.html"
     output_file = create_output_file(
         output_path,
-        display_name="Hayabusa_HTML_report.html",
+        display_name=display_name,
         data_type="openrelik:hayabusa:html_report",
     )
 


### PR DESCRIPTION
Added the ability to configure a custom name for the hayabusa .csv and .html output files when running the openrelik-worker-hayabusa task.

This makes it easier to not have the same .csv/.html file name after a processing run.

Would like to maybe add it so that the defaultname doesnt become "Hayabusa_*", but some unique identifier based on maybe file hash or timestamp.