### PR TITLE
Standardize Hayabusa task options

### DIFF
--- a/src/csv_timeline.py
+++ b/src/csv_timeline.py
@@ -22,14 +22,17 @@ from openrelik_worker_common.file_utils import create_output_file
 from openrelik_worker_common.task_utils import create_task_result, get_input_files
 
 from .app import celery
+from .hayabusa import build_timeline_command, output_display_name, timeline_task_config
 
 # Task name used to register and route the task to the correct queue.
 TASK_NAME = "openrelik-worker-hayabusa.tasks.csv_timeline"
+DEFAULT_DISPLAY_NAME = "Hayabusa_CSV_timeline.csv"
 
 # Task metadata for registration in the core system.
 TASK_METADATA = {
     "display_name": "Hayabusa CSV timeline",
     "description": "Windows event log triage",
+    "task_config": timeline_task_config(),
 }
 
 COMPATIBLE_INPUTS = {
@@ -43,10 +46,10 @@ COMPATIBLE_INPUTS = {
 def csv_timeline(
     self,
     pipe_result=None,
-    input_files=[],
+    input_files=None,
     output_path=None,
     workflow_id=None,
-    task_config={},
+    task_config=None,
 ) -> str:
     output_files = []
     input_files = get_input_files(pipe_result, input_files or [], filter=COMPATIBLE_INPUTS)
@@ -59,7 +62,7 @@ def csv_timeline(
 
     output_file = create_output_file(
         output_path,
-        display_name="Hayabusa_CSV_timeline.csv",
+        display_name=output_display_name(task_config, DEFAULT_DISPLAY_NAME, ".csv"),
         data_type="openrelik:hayabusa:csv",
     )
 
@@ -70,21 +73,12 @@ def csv_timeline(
         filename = os.path.basename(file.get("path"))
         os.link(file.get("path"), f"{temp_dir}/{filename}")
 
-    command = [
-        "/hayabusa/hayabusa",
+    command = build_timeline_command(
         "csv-timeline",
-        "--ISO-8601",
-        "--UTC",
-        "--no-wizard",
-        "--quiet",
-        "--profile",
-        "timesketch-verbose",
-        "--clobber",
-        "--output",
         output_file.path,
-        "--directory",
         temp_dir,
-    ]
+        task_config,
+    )
 
     INTERVAL_SECONDS = 2
     process = subprocess.Popen(command)

--- a/src/hayabusa.py
+++ b/src/hayabusa.py
@@ -1,0 +1,150 @@
+HAYABUSA_BINARY = "/hayabusa/hayabusa"
+
+DEFAULT_OUTPUT_PROFILE = "standard"
+DEFAULT_TIME_FORMAT = "UTC"
+
+OUTPUT_PROFILES = [
+    "minimal",
+    "standard",
+    "verbose",
+    "all-field-info",
+    "all-field-info-verbose",
+    "super-verbose",
+    "timesketch-minimal",
+    "timesketch-verbose",
+]
+
+TIME_FORMAT_FLAGS = {
+    "UTC": None,
+    "default": None,
+    "ISO-8601": "--ISO-8601",
+    "RFC-2822": "--RFC-2822",
+    "RFC-3339": "--RFC-3339",
+}
+
+TIME_FORMATS = [
+    "UTC",
+    "ISO-8601",
+    "RFC-2822",
+    "RFC-3339",
+]
+
+
+def timeline_task_config() -> list[dict[str, object]]:
+    return [
+        {
+            "name": "time_format",
+            "label": "Time format",
+            "description": (
+                "Output timestamps in UTC by default, or choose a specific "
+                "Hayabusa timestamp format."
+            ),
+            "type": "select",
+            "items": list(TIME_FORMATS),
+            "default": DEFAULT_TIME_FORMAT,
+            "required": False,
+        },
+        {
+            "name": "output_profile",
+            "label": "Output profile",
+            "description": "Hayabusa output profile.",
+            "type": "select",
+            "items": list(OUTPUT_PROFILES),
+            "default": DEFAULT_OUTPUT_PROFILE,
+            "required": False,
+        },
+        {
+            "name": "output_file_name",
+            "label": "Output file name",
+            "description": "Custom output file name.",
+            "type": "text",
+            "required": False,
+        },
+    ]
+
+
+def _config_value(task_config: dict | None, key: str, default: str) -> str:
+    if not isinstance(task_config, dict):
+        return default
+    value = (task_config or {}).get(key, default)
+    if isinstance(value, list):
+        value = value[0] if value else default
+    if value is None or value == "":
+        return default
+    return str(value)
+
+
+def output_profile(task_config: dict | None) -> str:
+    profile = _config_value(task_config, "output_profile", DEFAULT_OUTPUT_PROFILE)
+    if profile not in OUTPUT_PROFILES:
+        return DEFAULT_OUTPUT_PROFILE
+    return profile
+
+
+def time_format(task_config: dict | None) -> str:
+    selected_format = _config_value(task_config, "time_format", DEFAULT_TIME_FORMAT)
+    if selected_format not in TIME_FORMAT_FLAGS:
+        return DEFAULT_TIME_FORMAT
+    if selected_format == "default":
+        return DEFAULT_TIME_FORMAT
+    return selected_format
+
+
+def output_display_name(
+    task_config: dict | None,
+    default_display_name: str,
+    extension: str,
+) -> str:
+    display_name = _config_value(task_config, "output_file_name", "")
+    if not display_name:
+        return default_display_name
+
+    display_name = display_name.strip().replace("\\", "/").split("/")[-1]
+    if not display_name or display_name in {".", ".."}:
+        return default_display_name
+
+    normalized_extension = "." + extension.lstrip(".")
+    if display_name.lower().endswith(normalized_extension.lower()):
+        display_name = display_name[: -len(normalized_extension)]
+
+    if not display_name:
+        return default_display_name
+    return f"{display_name}{normalized_extension}"
+
+
+def build_timeline_command(
+    subcommand: str,
+    output_path: str,
+    input_directory: str,
+    task_config: dict | None,
+    html_report_path: str | None = None,
+) -> list[str]:
+    command = [
+        HAYABUSA_BINARY,
+        subcommand,
+        "--UTC",
+        "--no-wizard",
+        "--quiet",
+        "--profile",
+        output_profile(task_config),
+    ]
+
+    selected_time_format = time_format(task_config)
+    time_format_flag = TIME_FORMAT_FLAGS[selected_time_format]
+    if time_format_flag:
+        command.append(time_format_flag)
+
+    command.append("--clobber")
+
+    if html_report_path:
+        command.extend(["--HTML-report", html_report_path])
+
+    command.extend(
+        [
+            "--output",
+            output_path,
+            "--directory",
+            input_directory,
+        ]
+    )
+    return command

--- a/src/html_report.py
+++ b/src/html_report.py
@@ -21,17 +21,19 @@ from uuid import uuid4
 from openrelik_worker_common.file_utils import create_output_file
 from openrelik_worker_common.task_utils import create_task_result, get_input_files
 
-
 from .app import celery
+from .hayabusa import build_timeline_command, output_display_name, timeline_task_config
 
 
 # Task name used to register and route the task to the correct queue.
 TASK_NAME = "openrelik-worker-hayabusa.tasks.html_report"
+DEFAULT_DISPLAY_NAME = "Hayabusa_HTML_report.html"
 
 # Task metadata for registration in the core system.
 TASK_METADATA = {
     "display_name": "Hayabusa HTML report",
     "description": "Windows event log triage",
+    "task_config": timeline_task_config(),
 }
 
 COMPATIBLE_INPUTS = {
@@ -45,10 +47,10 @@ COMPATIBLE_INPUTS = {
 def html_report(
     self,
     pipe_result=None,
-    input_files=[],
+    input_files=None,
     output_path=None,
     workflow_id=None,
-    task_config={},
+    task_config=None,
 ) -> str:
     output_files = []
     input_files = get_input_files(
@@ -61,11 +63,9 @@ def html_report(
             command="",
         )
 
-    
-
     output_file = create_output_file(
         output_path,
-        display_name="Hayabusa_HTML_report.html",
+        display_name=output_display_name(task_config, DEFAULT_DISPLAY_NAME, ".html"),
         data_type="openrelik:hayabusa:html",
     )
 
@@ -76,21 +76,13 @@ def html_report(
         filename = os.path.basename(file.get("path"))
         os.link(file.get("path"), f"{temp_dir}/{filename}")
 
-    command = [
-        "/hayabusa/hayabusa",
+    command = build_timeline_command(
         "csv-timeline",
-        "--ISO-8601",
-        "--UTC",
-        "--no-wizard",
-        "--quiet",
-        "--clobber",
-        "--HTML-report",
-        output_file.path,
-        "--output",
         "/dev/null",
-        "--directory",
         temp_dir,
-    ]
+        task_config,
+        html_report_path=output_file.path,
+    )
 
     INTERVAL_SECONDS = 2
     process = subprocess.Popen(command)

--- a/src/json_timeline.py
+++ b/src/json_timeline.py
@@ -8,32 +8,17 @@ from openrelik_worker_common.file_utils import create_output_file
 from openrelik_worker_common.task_utils import create_task_result, get_input_files
 
 from .app import celery
+from .hayabusa import build_timeline_command, output_display_name, timeline_task_config
 
 # Task name used to register and route the task to the correct queue.
 TASK_NAME = "openrelik-worker-hayabusa.tasks.json_timeline"
+DEFAULT_DISPLAY_NAME = "Hayabusa_JSON_timeline.json"
 
 # Task metadata for registration in the core system.
 TASK_METADATA = {
     "display_name": "Hayabusa JSON timeline",
     "description": "Windows event log triage",
-    "task_config": [
-        {
-            "name": "time_format",
-            "label": "Default is YYYY-MM-DD HH:mm:ss.sss +hh:mm",
-            "description": "Time format",
-            "type": "select",
-            "items": [ "default", "ISO-8601", "RFC-2822", "RFC-3339" ],
-            "required": False,
-        },
-        {
-            "name": "output_profile",
-            "label": "Choose an output profile",
-            "description": "Output profile",
-            "type": "select",
-            "items": [ "minimal", "standard", "verbose", "all-field-info", "all-field-info-verbose", "super-verbose", "timesketch-minimal", "timesketch-verbose" ],
-            "required": False,
-        },
-    ],
+    "task_config": timeline_task_config(),
 }
 
 COMPATIBLE_INPUTS = {
@@ -47,10 +32,10 @@ COMPATIBLE_INPUTS = {
 def json_timeline(
     self,
     pipe_result=None,
-    input_files=[],
+    input_files=None,
     output_path=None,
     workflow_id=None,
-    task_config={},
+    task_config=None,
 ) -> str:
     output_files = []
     input_files = get_input_files(pipe_result, input_files or [], filter=COMPATIBLE_INPUTS)
@@ -63,7 +48,7 @@ def json_timeline(
 
     output_file = create_output_file(
         output_path,
-        display_name="Hayabusa_JSON_timeline.json",
+        display_name=output_display_name(task_config, DEFAULT_DISPLAY_NAME, ".json"),
         data_type="openrelik:hayabusa:json",
     )
 
@@ -74,28 +59,12 @@ def json_timeline(
         filename = os.path.basename(file.get("path"))
         os.link(file.get("path"), f"{temp_dir}/{filename}")
 
-    time_format = task_config.get("time_format", "default")
-    output_profile = task_config.get("output_profile", "standard")
-
-    # Basic command for generating a JSON timeline
-    command = [
-        "/hayabusa/hayabusa",
+    command = build_timeline_command(
         "json-timeline",
-        "--UTC",
-        "--no-wizard",
-        "--quiet",
-        "--profile",
-        output_profile,
-        "--clobber",
-        "--output",
         output_file.path,
-        "--directory",
         temp_dir,
-    ]
-
-    # If non-default time format is required, append the appropriate param to Hayabusa command
-    if time_format != "default":
-        command.append("--" + time_format)
+        task_config,
+    )
 
     INTERVAL_SECONDS = 2
     process = subprocess.Popen(command)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,12 +1,129 @@
-"""Tests tasks."""
+import os
 
-# Note: Use pytest for writing tests!
-import pytest
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
-# from src.tasks import command
+from src.hayabusa import (
+    DEFAULT_OUTPUT_PROFILE,
+    DEFAULT_TIME_FORMAT,
+    build_timeline_command,
+    output_display_name,
+    output_profile,
+    time_format,
+)
+from src.csv_timeline import TASK_METADATA as CSV_TASK_METADATA
+from src.html_report import TASK_METADATA as HTML_TASK_METADATA
+from src.json_timeline import TASK_METADATA as JSON_TASK_METADATA
 
-def test_task_command():
-    """Test command task."""
 
-    ret = "some dummy return value"
-    assert isinstance(ret,str)
+def test_default_timeline_command_uses_utc_and_standard_profile():
+    command = build_timeline_command(
+        "csv-timeline",
+        "/tmp/out.csv",
+        "/tmp/input",
+        task_config={},
+    )
+
+    assert command == [
+        "/hayabusa/hayabusa",
+        "csv-timeline",
+        "--UTC",
+        "--no-wizard",
+        "--quiet",
+        "--profile",
+        DEFAULT_OUTPUT_PROFILE,
+        "--clobber",
+        "--output",
+        "/tmp/out.csv",
+        "--directory",
+        "/tmp/input",
+    ]
+    assert DEFAULT_TIME_FORMAT == "UTC"
+
+
+def test_timeline_command_applies_time_format_and_profile_overrides():
+    command = build_timeline_command(
+        "json-timeline",
+        "/tmp/out.json",
+        "/tmp/input",
+        task_config={
+            "time_format": "RFC-3339",
+            "output_profile": "timesketch-verbose",
+        },
+    )
+
+    assert "--UTC" in command
+    assert command[command.index("--profile") + 1] == "timesketch-verbose"
+    assert "--RFC-3339" in command
+
+
+def test_html_command_applies_profile_and_html_report_output():
+    command = build_timeline_command(
+        "csv-timeline",
+        "/dev/null",
+        "/tmp/input",
+        task_config={"output_profile": "verbose"},
+        html_report_path="/tmp/report.html",
+    )
+
+    assert command[command.index("--profile") + 1] == "verbose"
+    assert command[command.index("--HTML-report") + 1] == "/tmp/report.html"
+    assert command[command.index("--output") + 1] == "/dev/null"
+
+
+def test_invalid_options_fall_back_to_shared_defaults():
+    task_config = {
+        "time_format": "not-a-format",
+        "output_profile": "not-a-profile",
+    }
+
+    assert time_format(task_config) == DEFAULT_TIME_FORMAT
+    assert output_profile(task_config) == DEFAULT_OUTPUT_PROFILE
+
+
+def test_legacy_default_time_format_maps_to_utc_default():
+    assert time_format({"time_format": "default"}) == DEFAULT_TIME_FORMAT
+
+
+def test_output_display_name_defaults_when_not_configured():
+    assert (
+        output_display_name({}, "Hayabusa_CSV_timeline.csv", ".csv")
+        == "Hayabusa_CSV_timeline.csv"
+    )
+
+
+def test_output_display_name_appends_expected_extension():
+    assert (
+        output_display_name(
+            {"output_file_name": "case-964-hayabusa"},
+            "default.csv",
+            ".csv",
+        )
+        == "case-964-hayabusa.csv"
+    )
+
+
+def test_output_display_name_does_not_duplicate_expected_extension():
+    assert (
+        output_display_name(
+            {"output_file_name": "case-964.json"},
+            "default.json",
+            ".json",
+        )
+        == "case-964.json"
+    )
+
+
+def test_output_display_name_uses_basename_for_path_like_values():
+    assert (
+        output_display_name(
+            {"output_file_name": "../case-964/report"},
+            "default.html",
+            ".html",
+        )
+        == "report.html"
+    )
+
+
+def test_all_tasks_expose_the_same_hayabusa_options():
+    assert CSV_TASK_METADATA["task_config"] == JSON_TASK_METADATA["task_config"]
+    assert HTML_TASK_METADATA["task_config"] == JSON_TASK_METADATA["task_config"]


### PR DESCRIPTION
## Summary
- Add shared Hayabusa task option handling for CSV, JSON, and HTML outputs.
- Expose common time format, output profile, and output file name settings across all three tasks.
- Apply output profile support to the HTML report task.
- Avoid mutable default arguments in task functions.

## Validation
- `poetry run pytest -q`
- `poetry run python -m compileall -q src tests`
- `git diff --check`
- `poetry check`
- `docker compose build openrelik-worker-hayabusa`
