### PR TITLE
Fixed mistake of default profile being "standard" instead of "timesketch-verbose"

### DIFF
--- a/src/hayabusa.py
+++ b/src/hayabusa.py
@@ -1,6 +1,6 @@
 HAYABUSA_BINARY = "/hayabusa/hayabusa"
 
-DEFAULT_OUTPUT_PROFILE = "standard"
+DEFAULT_OUTPUT_PROFILE = "timesketch-verbose"
 DEFAULT_TIME_FORMAT = "UTC"
 
 OUTPUT_PROFILES = [

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -15,7 +15,7 @@ from src.html_report import TASK_METADATA as HTML_TASK_METADATA
 from src.json_timeline import TASK_METADATA as JSON_TASK_METADATA
 
 
-def test_default_timeline_command_uses_utc_and_standard_profile():
+def test_default_timeline_command_uses_utc_and_timesketch_verbose_profile():
     command = build_timeline_command(
         "csv-timeline",
         "/tmp/out.csv",


### PR DESCRIPTION
The last commit changes the default profile to "standard" instead of "timesketch-verbose" which made it so that the output of the CSV can't be loaded into Timesketch anymore cleanly. This fixes this problem.

This was default behaviour before my last commit.